### PR TITLE
Add local time of day to AI API request

### DIFF
--- a/app/actions/ai.ts
+++ b/app/actions/ai.ts
@@ -16,6 +16,7 @@ interface GetResponseParams {
   totalPrecip: number;
   avgHumidity: number;
   condition: string;
+  time: string;
 }
 
 type ShortsResponse = {
@@ -33,6 +34,7 @@ export async function getResponse({
   totalPrecip,
   avgHumidity,
   condition,
+  time,
 }: GetResponseParams): Promise<ShortsResponse> {
   try {
     const response = await client.responses.parse({
@@ -41,7 +43,8 @@ export async function getResponse({
         {
           role: "developer",
           content: `It decides if should use pants based on an user that is on ${city} city on ${country} country with today's weather condition of:
-      
+
+      - Local Time: ${time}
       - Max temperature: ${maxTemp}
       - Min temperature: ${minTemp}
       - Average Temperature: ${avgTemp}

--- a/app/actions/shorts.ts
+++ b/app/actions/shorts.ts
@@ -5,16 +5,17 @@ import { getWeather } from "./weather";
 interface GetShortsParams {
   city: string;
   country: string;
+  time: string;
 }
 
-export async function getShorts({ city, country }: GetShortsParams) {
+export async function getShorts({ city, country, time }: GetShortsParams) {
   if (!runUsage()) {
     throw new Error("No more usages");
   }
 
   try {
     const weather = await getWeather({ city });
-    const response = await getResponse({ ...weather, city, country });
+    const response = await getResponse({ ...weather, city, country, time });
 
     addWearShorts(response.wearShorts);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,20 @@ export default function Home() {
 
   const [{ status, value }, check] = useAsync(async () => {
     if (!location) return null;
-    return await getShorts({ city: location.city, country: location.country });
+    const now = new Date();
+    const time = now.toLocaleString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric'
+    });
+    return await getShorts({
+      city: location.city,
+      country: location.country,
+      time
+    });
   });
 
   // Wait for geolocation to load


### PR DESCRIPTION
- Capture user's local time on client side to preserve timezone
- Format time as readable string (e.g., "Mon, Dec 9, 02:30 PM")
- Pass time string through server actions to avoid UTC conversion
- Include local time in AI prompt for better shorts recommendations
- Time context helps AI make more accurate decisions based on time of day