### PR TITLE
Use neighborhood instead of city for more precise location

### DIFF
--- a/app/actions/ai.ts
+++ b/app/actions/ai.ts
@@ -8,7 +8,7 @@ const client = new OpenAI({
 
 interface GetResponseParams {
   country: string;
-  city: string;
+  neighborhood: string;
   maxTemp: number;
   minTemp: number;
   avgTemp: number;
@@ -26,7 +26,7 @@ type ShortsResponse = {
 
 export async function getResponse({
   country,
-  city,
+  neighborhood,
   maxTemp,
   minTemp,
   avgTemp,
@@ -42,7 +42,7 @@ export async function getResponse({
       input: [
         {
           role: "developer",
-          content: `It decides if should use pants based on an user that is on ${city} city on ${country} country with today's weather condition of:
+          content: `It decides if should use pants based on an user that is on ${neighborhood} neighborhood in ${country} country with today's weather condition of:
 
       - Local Time: ${time}
       - Max temperature: ${maxTemp}

--- a/app/actions/shorts.ts
+++ b/app/actions/shorts.ts
@@ -3,19 +3,19 @@ import { getResponse } from "./ai";
 import { getWeather } from "./weather";
 
 interface GetShortsParams {
-  city: string;
+  neighborhood: string;
   country: string;
   time: string;
 }
 
-export async function getShorts({ city, country, time }: GetShortsParams) {
+export async function getShorts({ neighborhood, country, time }: GetShortsParams) {
   if (!runUsage()) {
     throw new Error("No more usages");
   }
 
   try {
-    const weather = await getWeather({ city });
-    const response = await getResponse({ ...weather, city, country, time });
+    const weather = await getWeather({ neighborhood });
+    const response = await getResponse({ ...weather, neighborhood, country, time });
 
     addWearShorts(response.wearShorts);
 

--- a/app/actions/weather.ts
+++ b/app/actions/weather.ts
@@ -1,14 +1,14 @@
 "use server";
 
 interface GetWeatherParams {
-  city: string;
+  neighborhood: string;
 }
 
-export async function getWeather({ city }: GetWeatherParams) {
+export async function getWeather({ neighborhood }: GetWeatherParams) {
   const response = await fetch(
     `https://api.weatherapi.com/v1/forecast.json?key=${
       process.env.WEATHER_API
-    }&q=${city?.replace(" ", "%20")}&aqi=no)}`
+    }&q=${neighborhood?.replace(" ", "%20")}&aqi=no)}`
   );
   const data = await response.json();
   const maxTemp = data.forecast.forecastday[0].day.maxtemp_c;

--- a/app/hooks.ts
+++ b/app/hooks.ts
@@ -59,7 +59,7 @@ export function useLastDecision() {
 }
 
 interface LocationData {
-  city: string;
+  neighborhood: string;
   country: string;
 }
 
@@ -91,10 +91,10 @@ export function useGeolocation() {
           );
 
           const data = await response.json();
-          const city = data.address.city || data.address.town || data.address.village || data.address.county || "Unknown";
+          const neighborhood = data.address.neighbourhood || data.address.suburb || data.address.quarter || data.address.city_district || data.address.city || data.address.town || data.address.village || "Unknown";
           const country = data.address.country_code?.toUpperCase() || "US";
 
-          setLocation({ city, country });
+          setLocation({ neighborhood, country });
           setLoading(false);
         } catch (err) {
           setError("Failed to get location information");

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
       day: 'numeric'
     });
     return await getShorts({
-      city: location.city,
+      neighborhood: location.neighborhood,
       country: location.country,
       time
     });
@@ -40,7 +40,7 @@ export default function Home() {
       <Background wearShorts={false} status="idle">
         <div className="flex justify-center items-center min-h-[100dvh] text-neutral-950 dark:text-neutral-50 relative z-20">
           <Idle
-            city="..."
+            neighborhood="..."
             country="..."
             isLoading={true}
             check={async () => {}}
@@ -63,7 +63,7 @@ export default function Home() {
 
   let children = (
     <Idle
-      city={location.city}
+      neighborhood={location.neighborhood}
       country={location.country}
       isLoading={status === "loading"}
       check={check}

--- a/app/views/Idle/index.tsx
+++ b/app/views/Idle/index.tsx
@@ -12,11 +12,11 @@ import { CONTENT } from "./translatables";
 interface IdleParams {
   check(): Promise<void>;
   isLoading: boolean;
-  city: string;
+  neighborhood: string;
   country: string;
 }
 
-export const Idle = ({ check, isLoading, city, country }: IdleParams) => {
+export const Idle = ({ check, isLoading, neighborhood, country }: IdleParams) => {
   const uses = useShortsUses();
   const lang = useLang();
   const countryInfo = countries.find((x) => x.cca2 === country);
@@ -29,7 +29,7 @@ export const Idle = ({ check, isLoading, city, country }: IdleParams) => {
       <div className="flex flex-col gap-4 justify-center items-center">
         <div className="text-xl flex gap-2 items-center justify-center">
           <span>{flag}</span>
-          <span>{city}</span>
+          <span>{neighborhood}</span>
         </div>
         <h1 className="text-3xl font-bold">
           {content.title}


### PR DESCRIPTION
- Update reverse geocoding to prioritize neighbourhood, suburb, quarter,
  and city_district from OpenStreetMap API
- Rename 'city' to 'neighborhood' across all interfaces and functions
- Update AI prompt to reference neighborhood context